### PR TITLE
Update Settings.vb to refresh Richtextboxes after edit

### DIFF
--- a/WinBackupper/Settings.Designer.vb
+++ b/WinBackupper/Settings.Designer.vb
@@ -68,9 +68,9 @@ Partial Class Settings
         'b_save
         '
         Me.b_save.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.b_save.Location = New System.Drawing.Point(8, 377)
+        Me.b_save.Location = New System.Drawing.Point(121, 419)
         Me.b_save.Name = "b_save"
-        Me.b_save.Size = New System.Drawing.Size(434, 35)
+        Me.b_save.Size = New System.Drawing.Size(321, 35)
         Me.b_save.TabIndex = 18
         Me.b_save.Text = "Save"
         Me.b_save.UseVisualStyleBackColor = True
@@ -87,7 +87,7 @@ Partial Class Settings
         'b_addfolderpair
         '
         Me.b_addfolderpair.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.b_addfolderpair.Location = New System.Drawing.Point(8, 344)
+        Me.b_addfolderpair.Location = New System.Drawing.Point(12, 378)
         Me.b_addfolderpair.Name = "b_addfolderpair"
         Me.b_addfolderpair.Size = New System.Drawing.Size(202, 35)
         Me.b_addfolderpair.TabIndex = 19
@@ -100,7 +100,7 @@ Partial Class Settings
         Me.l_settings.BackColor = System.Drawing.Color.Transparent
         Me.l_settings.Font = New System.Drawing.Font("Microsoft Sans Serif", 15.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.l_settings.ForeColor = System.Drawing.SystemColors.ButtonFace
-        Me.l_settings.Location = New System.Drawing.Point(168, 23)
+        Me.l_settings.Location = New System.Drawing.Point(184, 24)
         Me.l_settings.Name = "l_settings"
         Me.l_settings.Size = New System.Drawing.Size(90, 25)
         Me.l_settings.TabIndex = 10
@@ -116,10 +116,10 @@ Partial Class Settings
         '
         'RTB_Backuppath
         '
-        Me.RTB_Backuppath.Location = New System.Drawing.Point(225, 79)
+        Me.RTB_Backuppath.Location = New System.Drawing.Point(240, 79)
         Me.RTB_Backuppath.Name = "RTB_Backuppath"
         Me.RTB_Backuppath.ShowSelectionMargin = True
-        Me.RTB_Backuppath.Size = New System.Drawing.Size(214, 142)
+        Me.RTB_Backuppath.Size = New System.Drawing.Size(202, 142)
         Me.RTB_Backuppath.TabIndex = 22
         Me.RTB_Backuppath.Text = ""
         '
@@ -128,7 +128,7 @@ Partial Class Settings
         Me.RTB_Sourcepath.Location = New System.Drawing.Point(12, 79)
         Me.RTB_Sourcepath.Name = "RTB_Sourcepath"
         Me.RTB_Sourcepath.ShowSelectionMargin = True
-        Me.RTB_Sourcepath.Size = New System.Drawing.Size(198, 142)
+        Me.RTB_Sourcepath.Size = New System.Drawing.Size(202, 142)
         Me.RTB_Sourcepath.TabIndex = 21
         Me.RTB_Sourcepath.Text = ""
         '
@@ -136,9 +136,9 @@ Partial Class Settings
         '
         Me.b_reset.BackColor = System.Drawing.Color.LightCoral
         Me.b_reset.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.b_reset.Location = New System.Drawing.Point(11, 19)
+        Me.b_reset.Location = New System.Drawing.Point(12, 418)
         Me.b_reset.Name = "b_reset"
-        Me.b_reset.Size = New System.Drawing.Size(100, 36)
+        Me.b_reset.Size = New System.Drawing.Size(103, 36)
         Me.b_reset.TabIndex = 23
         Me.b_reset.Text = "Reset!"
         Me.b_reset.UseVisualStyleBackColor = False
@@ -146,19 +146,19 @@ Partial Class Settings
         'b_editfolderpair
         '
         Me.b_editfolderpair.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.b_editfolderpair.Location = New System.Drawing.Point(225, 344)
+        Me.b_editfolderpair.Location = New System.Drawing.Point(240, 378)
         Me.b_editfolderpair.Name = "b_editfolderpair"
-        Me.b_editfolderpair.Size = New System.Drawing.Size(217, 35)
+        Me.b_editfolderpair.Size = New System.Drawing.Size(202, 35)
         Me.b_editfolderpair.TabIndex = 24
         Me.b_editfolderpair.Text = "Edit Entry"
         Me.b_editfolderpair.UseVisualStyleBackColor = True
         '
         'rtb_backupstarttimes
         '
-        Me.rtb_backupstarttimes.Location = New System.Drawing.Point(11, 255)
+        Me.rtb_backupstarttimes.Location = New System.Drawing.Point(12, 255)
         Me.rtb_backupstarttimes.Name = "rtb_backupstarttimes"
         Me.rtb_backupstarttimes.ShowSelectionMargin = True
-        Me.rtb_backupstarttimes.Size = New System.Drawing.Size(427, 59)
+        Me.rtb_backupstarttimes.Size = New System.Drawing.Size(430, 59)
         Me.rtb_backupstarttimes.TabIndex = 25
         Me.rtb_backupstarttimes.Text = ""
         '
@@ -180,7 +180,7 @@ Partial Class Settings
         Me.cb_Autostart.BackColor = System.Drawing.Color.Transparent
         Me.cb_Autostart.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.cb_Autostart.ForeColor = System.Drawing.SystemColors.ButtonFace
-        Me.cb_Autostart.Location = New System.Drawing.Point(14, 317)
+        Me.cb_Autostart.Location = New System.Drawing.Point(12, 320)
         Me.cb_Autostart.Name = "cb_Autostart"
         Me.cb_Autostart.Size = New System.Drawing.Size(313, 21)
         Me.cb_Autostart.TabIndex = 27
@@ -193,7 +193,7 @@ Partial Class Settings
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.BackColor = System.Drawing.SystemColors.ControlLightLight
         Me.BackgroundImage = Global.WinBackupper.My.Resources.Resources.gray_background_3
-        Me.ClientSize = New System.Drawing.Size(454, 420)
+        Me.ClientSize = New System.Drawing.Size(454, 466)
         Me.Controls.Add(Me.cb_Autostart)
         Me.Controls.Add(Me.l_backuptimes)
         Me.Controls.Add(Me.rtb_backupstarttimes)

--- a/WinBackupper/Settings.vb
+++ b/WinBackupper/Settings.vb
@@ -389,6 +389,9 @@ Public Class Settings
             'sane string ...add it
             'write value into Array!
             sourcepatharray.Add(SourcePathtresult)
+
+            'Refresh Richtextbox to display selected Path instantly
+            RTB_Sourcepath.AppendText(SourcePathtresult & vbNewLine)
         End If
 
         ' Dialog to select Backup Path
@@ -410,6 +413,9 @@ Public Class Settings
             'sane string ...add it
             'write value into Array!
             backupPatharray.Add(BackupPathresult)
+
+            'Refresh Richtextbox to display selected Path instantly
+            RTB_Backuppath.AppendText(BackupPathresult & vbNewLine)
         End If
     End Sub
 

--- a/WinBackupper/Settings.vb
+++ b/WinBackupper/Settings.vb
@@ -205,7 +205,6 @@ Public Class Settings
         End If
         'start bw_writer which writes default.xml in backgournd (other thread)
         bw_writer.RunWorkerAsync()
-
     End Sub
 
     Private Sub b_reset_Click(sender As Object, e As EventArgs) Handles b_reset.Click
@@ -217,13 +216,16 @@ Public Class Settings
                 'delete it 
                 System.IO.File.Delete(getexedir() & "\default.xml")
             End If
+            'Clear Array
             sourcepatharray.Clear()
             backupPatharray.Clear()
+            'Refresh Richtextbox
+            RTB_Sourcepath.Clear()
+            RTB_Backuppath.Clear()
         Else
             'user aborted - maybe misclicked 
             MessageBox.Show("Reseting Configuration Aborted!", "Aborted", MessageBoxButtons.OK, MessageBoxIcon.Information)
         End If
-
 
     End Sub
 

--- a/WinBackupper/home.Designer.vb
+++ b/WinBackupper/home.Designer.vb
@@ -86,7 +86,7 @@ Partial Class home
         'b_settings
         '
         Me.b_settings.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.b_settings.Location = New System.Drawing.Point(12, 267)
+        Me.b_settings.Location = New System.Drawing.Point(12, 271)
         Me.b_settings.Name = "b_settings"
         Me.b_settings.Size = New System.Drawing.Size(135, 35)
         Me.b_settings.TabIndex = 8
@@ -102,7 +102,7 @@ Partial Class home
         'b_update
         '
         Me.b_update.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.b_update.Location = New System.Drawing.Point(153, 267)
+        Me.b_update.Location = New System.Drawing.Point(153, 271)
         Me.b_update.Name = "b_update"
         Me.b_update.Size = New System.Drawing.Size(136, 35)
         Me.b_update.TabIndex = 10
@@ -114,7 +114,7 @@ Partial Class home
         Me.l_version.AutoSize = True
         Me.l_version.BackColor = System.Drawing.Color.Transparent
         Me.l_version.ForeColor = System.Drawing.SystemColors.ButtonFace
-        Me.l_version.Location = New System.Drawing.Point(363, 278)
+        Me.l_version.Location = New System.Drawing.Point(365, 282)
         Me.l_version.Name = "l_version"
         Me.l_version.Size = New System.Drawing.Size(77, 13)
         Me.l_version.TabIndex = 11
@@ -125,17 +125,17 @@ Partial Class home
         '
         'RTB_Sourcepath
         '
-        Me.RTB_Sourcepath.Location = New System.Drawing.Point(15, 82)
+        Me.RTB_Sourcepath.Location = New System.Drawing.Point(12, 82)
         Me.RTB_Sourcepath.Name = "RTB_Sourcepath"
-        Me.RTB_Sourcepath.Size = New System.Drawing.Size(198, 142)
+        Me.RTB_Sourcepath.Size = New System.Drawing.Size(202, 142)
         Me.RTB_Sourcepath.TabIndex = 12
         Me.RTB_Sourcepath.Text = ""
         '
         'RTB_Backuppath
         '
-        Me.RTB_Backuppath.Location = New System.Drawing.Point(228, 82)
+        Me.RTB_Backuppath.Location = New System.Drawing.Point(240, 82)
         Me.RTB_Backuppath.Name = "RTB_Backuppath"
-        Me.RTB_Backuppath.Size = New System.Drawing.Size(214, 142)
+        Me.RTB_Backuppath.Size = New System.Drawing.Size(202, 142)
         Me.RTB_Backuppath.TabIndex = 13
         Me.RTB_Backuppath.Text = ""
         '
@@ -145,7 +145,7 @@ Partial Class home
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.BackColor = System.Drawing.SystemColors.ControlLightLight
         Me.BackgroundImage = Global.WinBackupper.My.Resources.Resources.gray_background_3
-        Me.ClientSize = New System.Drawing.Size(454, 321)
+        Me.ClientSize = New System.Drawing.Size(454, 318)
         Me.Controls.Add(Me.RTB_Backuppath)
         Me.Controls.Add(Me.RTB_Sourcepath)
         Me.Controls.Add(Me.l_version)


### PR DESCRIPTION
I added this code on line 394 and 418 to update the Richtextbox instantly after the user selects a Source or Backup Path:
"RTB_Sourcepath.AppendText(SourcePathtresult & vbNewLine)"

I also changed a bit of its design.
